### PR TITLE
Implement deps task

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,10 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: [
+    "mix.exs",
+    "{config,test}/**/*.{ex,exs}",
+    "lib/*.{ex,exs}",
+    "lib/interfaces/**/*.{ex,exs}",
+    "lib/tasks/**/*.{ex,exs}",
+  ]
 ]

--- a/lib/opts.ex
+++ b/lib/opts.ex
@@ -1,0 +1,22 @@
+defmodule WandCore.Opts do
+  def encode(opts), do: convert_opts(opts, :encode)
+  def decode(opts), do: convert_opts(opts, :decode)
+
+  def convert_opts(%{}=opts, mode) do
+    Enum.map(opts, fn
+      {key, value} when is_atom(value) and mode == :encode -> {key, ":#{value}"}
+      {key, ":" <> value} when mode == :decode -> {key, value}
+      {key, value} when is_list(value) -> {key, convert_opts(value, mode)}
+      {key, value} when is_map(value) -> {key, convert_opts(value, mode)}
+      {key, value} -> {key, value}
+    end)
+    |> Enum.into(%{})
+  end
+
+  def convert_opts(opts, mode) when is_list(opts) do
+    Enum.with_index(opts)
+    |> Enum.into(%{}, fn {k,v} -> {v,k} end)
+    |> convert_opts(mode)
+    |> Map.values()
+  end
+end

--- a/lib/opts.ex
+++ b/lib/opts.ex
@@ -5,7 +5,7 @@ defmodule WandCore.Opts do
   def convert_opts(%{}=opts, mode) do
     Enum.map(opts, fn
       {key, value} when is_atom(value) and mode == :encode -> {key, ":#{value}"}
-      {key, ":" <> value} when mode == :decode -> {key, value}
+      {key, ":" <> value} when mode == :decode -> {key, String.to_atom(value)}
       {key, value} when is_list(value) -> {key, convert_opts(value, mode)}
       {key, value} when is_map(value) -> {key, convert_opts(value, mode)}
       {key, value} -> {key, value}

--- a/lib/opts.ex
+++ b/lib/opts.ex
@@ -2,7 +2,7 @@ defmodule WandCore.Opts do
   def encode(opts), do: convert_opts(opts, :encode)
   def decode(opts), do: convert_opts(opts, :decode)
 
-  def convert_opts(%{}=opts, mode) do
+  def convert_opts(%{} = opts, mode) do
     Enum.map(opts, fn
       {key, value} when is_atom(value) and mode == :encode -> {key, ":#{value}"}
       {key, ":" <> value} when mode == :decode -> {key, String.to_atom(value)}
@@ -15,7 +15,7 @@ defmodule WandCore.Opts do
 
   def convert_opts(opts, mode) when is_list(opts) do
     Enum.with_index(opts)
-    |> Enum.into(%{}, fn {k,v} -> {v,k} end)
+    |> Enum.into(%{}, fn {k, v} -> {v, k} end)
     |> convert_opts(mode)
     |> Map.values()
   end

--- a/lib/tasks/deps.ex
+++ b/lib/tasks/deps.ex
@@ -9,15 +9,19 @@ defmodule Mix.Tasks.WandCore.Deps do
     Enum.map(file.dependencies, &convert_dependency/1)
   end
 
-  defp convert_dependency(%Dependency{name: name, requirement: requirement, opts: opts}) when opts == %{} do
+  defp convert_dependency(%Dependency{name: name, requirement: requirement, opts: opts})
+       when opts == %{} do
     {String.to_atom(name), requirement}
   end
 
-  defp convert_dependency(%Dependency{}=dependency) do
+  defp convert_dependency(%Dependency{} = dependency) do
     name = String.to_atom(dependency.name)
     requirement = dependency.requirement
-    opts = Opts.decode(dependency.opts)
-    |> Enum.into([])
+
+    opts =
+      Opts.decode(dependency.opts)
+      |> Enum.into([])
+
     {name, requirement, opts}
   end
 end

--- a/lib/tasks/deps.ex
+++ b/lib/tasks/deps.ex
@@ -1,0 +1,23 @@
+defmodule Mix.Tasks.WandCore.Deps do
+  use Mix.Task
+  alias WandCore.Opts
+  alias WandCore.WandFile
+  alias WandCore.WandFile.Dependency
+
+  def run(_args) do
+    {:ok, file} = WandFile.load()
+    Enum.map(file.dependencies, &convert_dependency/1)
+  end
+
+  defp convert_dependency(%Dependency{name: name, requirement: requirement, opts: opts}) when opts == %{} do
+    {String.to_atom(name), requirement}
+  end
+
+  defp convert_dependency(%Dependency{}=dependency) do
+    name = String.to_atom(dependency.name)
+    requirement = dependency.requirement
+    opts = Opts.decode(dependency.opts)
+    |> Enum.into([])
+    {name, requirement, opts}
+  end
+end

--- a/lib/tasks/get_deps.ex
+++ b/lib/tasks/get_deps.ex
@@ -6,6 +6,6 @@ defmodule Mix.Tasks.WandCore.GetDeps do
     @project.config()
     |> Keyword.get(:deps, [])
     |> WandCore.Poison.encode!()
-    |> IO.puts
+    |> IO.puts()
   end
 end

--- a/lib/wand_encoder.ex
+++ b/lib/wand_encoder.ex
@@ -45,7 +45,7 @@ defmodule Wand.WandEncoder do
     end
 
     def encode(%Dependency{requirement: requirement, opts: opts}, options) do
-      [requirement, convert_opts(opts)]
+      [requirement, WandCore.Opts.encode(opts)]
       |> Encoder.List.encode(options)
     end
 
@@ -71,23 +71,6 @@ defmodule Wand.WandEncoder do
         ]
       end)
       |> tl
-    end
-
-    defp convert_opts(%{}=opts) do
-      Enum.map(opts, fn
-        {key, value} when is_atom(value) -> {key, ":#{value}"}
-        {key, value} when is_list(value) -> {key, convert_opts(value)}
-        {key, value} when is_map(value) -> {key, convert_opts(value)}
-        {key, value} -> {key, value}
-      end)
-      |> Enum.into(%{})
-    end
-
-    defp convert_opts(opts) when is_list(opts) do
-      Enum.with_index(opts)
-      |> Enum.into(%{}, fn {k,v} -> {v,k} end)
-      |> convert_opts()
-      |> Map.values()
     end
 
     defp indent(options) do

--- a/lib/wand_encoder.ex
+++ b/lib/wand_encoder.ex
@@ -45,6 +45,7 @@ defmodule Wand.WandEncoder do
     end
 
     def encode(%Dependency{requirement: requirement, opts: opts}, options) do
+      options = Keyword.drop(options, [:pretty])
       [requirement, WandCore.Opts.encode(opts)]
       |> Encoder.List.encode(options)
     end

--- a/lib/wand_encoder.ex
+++ b/lib/wand_encoder.ex
@@ -46,6 +46,7 @@ defmodule Wand.WandEncoder do
 
     def encode(%Dependency{requirement: requirement, opts: opts}, options) do
       options = Keyword.drop(options, [:pretty])
+
       [requirement, WandCore.Opts.encode(opts)]
       |> Encoder.List.encode(options)
     end

--- a/lib/wand_encoder.ex
+++ b/lib/wand_encoder.ex
@@ -45,7 +45,7 @@ defmodule Wand.WandEncoder do
     end
 
     def encode(%Dependency{requirement: requirement, opts: opts}, options) do
-      [requirement, opts]
+      [requirement, convert_opts(opts)]
       |> Encoder.List.encode(options)
     end
 
@@ -71,6 +71,23 @@ defmodule Wand.WandEncoder do
         ]
       end)
       |> tl
+    end
+
+    defp convert_opts(%{}=opts) do
+      Enum.map(opts, fn
+        {key, value} when is_atom(value) -> {key, ":#{value}"}
+        {key, value} when is_list(value) -> {key, convert_opts(value)}
+        {key, value} when is_map(value) -> {key, convert_opts(value)}
+        {key, value} -> {key, value}
+      end)
+      |> Enum.into(%{})
+    end
+
+    defp convert_opts(opts) when is_list(opts) do
+      Enum.with_index(opts)
+      |> Enum.into(%{}, fn {k,v} -> {v,k} end)
+      |> convert_opts()
+      |> Map.values()
     end
 
     defp indent(options) do

--- a/lib/wand_file.ex
+++ b/lib/wand_file.ex
@@ -95,6 +95,7 @@ defmodule WandCore.WandFile do
 
   defp create_dependency(name, requirement, opts) do
     name = to_string(name)
+    opts = WandCore.Opts.decode(opts)
 
     case Version.parse_requirement(requirement) do
       :error -> {:error, {:invalid_dependency, name}}

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,8 @@ defmodule WandCore.MixProject do
 
   @version "0.2.0"
   @description "Global tasks for interacting with wand"
-  @cli_env  [
-    "coveralls": :test,
+  @cli_env [
+    coveralls: :test,
     "coveralls.detail": :test,
     "coveralls.post": :test,
     "coveralls.html": :test
@@ -22,7 +22,7 @@ defmodule WandCore.MixProject do
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: @cli_env,
       deps: deps(),
-      package: package(),
+      package: package()
     ]
   end
 
@@ -34,9 +34,10 @@ defmodule WandCore.MixProject do
 
   defp aliases do
     [
-      build: [&build_archive/1],
+      build: [&build_archive/1]
     ]
   end
+
   defp build_archive(_) do
     Mix.Tasks.Compile.run([])
     Mix.Tasks.Archive.Build.run(["--output=wand.ez"])
@@ -49,7 +50,7 @@ defmodule WandCore.MixProject do
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:excoveralls, "~> 0.9.1", only: :test},
       {:junit_formatter, "~> 2.2", only: :test},
-      {:mox, "~> 0.3.2", only: :test},
+      {:mox, "~> 0.3.2", only: :test}
     ]
   end
 
@@ -57,12 +58,13 @@ defmodule WandCore.MixProject do
   defp elixirc_paths(_), do: ["lib"]
 
   defp package do
-    [ name: :wand_core,
+    [
+      name: :wand_core,
       files: ["lib", "mix.exs"],
       docs: [extras: ["README.md"]],
       maintainers: ["Anil Kulkarni"],
       licenses: ["BSD-3"],
-      links: %{"Github" => "https://github.com/AnilRedshift/wand-core"},
+      links: %{"Github" => "https://github.com/AnilRedshift/wand-core"}
     ]
   end
 end

--- a/test/deps_test.exs
+++ b/test/deps_test.exs
@@ -20,9 +20,10 @@ defmodule DepsTest do
       ]
     }
     |> stub_read()
+
     assert Deps.run([]) == [
-      {:poison, "~>3.1.2"},
-    ]
+             {:poison, "~>3.1.2"}
+           ]
   end
 
   test "Converts multiple dependencies" do
@@ -33,10 +34,11 @@ defmodule DepsTest do
       ]
     }
     |> stub_read()
+
     assert Deps.run([]) == [
-      {:mox, "~> 1.2.3"},
-      {:poison, "~> 3.1.2"},
-    ]
+             {:mox, "~> 1.2.3"},
+             {:poison, "~> 3.1.2"}
+           ]
   end
 
   test "converts a dependency with opts" do
@@ -52,9 +54,10 @@ defmodule DepsTest do
       ]
     }
     |> stub_read()
+
     assert Deps.run([]) == [
-      {:poison, "~>3.1.2", only: :test},
-    ]
+             {:poison, "~>3.1.2", only: :test}
+           ]
   end
 
   test "converts a dependency with complex opts" do
@@ -73,18 +76,20 @@ defmodule DepsTest do
       ]
     }
     |> stub_read()
+
     assert Deps.run([]) == [
-      {:poison, "~>3.1.2", [
-        compile_env: :prod,
-        git: "https://github.com/devinus/poison.git",
-        only: [:test, :dev],
-        runtime: false,
-      ]},
-    ]
+             {:poison, "~>3.1.2",
+              [
+                compile_env: :prod,
+                git: "https://github.com/devinus/poison.git",
+                only: [:test, :dev],
+                runtime: false
+              ]}
+           ]
   end
 
   defp stub_read(file) do
     contents = WandCore.Poison.encode!(file)
-      expect(WandCore.FileMock, :read, fn "wand.json" -> {:ok, contents} end)
+    expect(WandCore.FileMock, :read, fn "wand.json" -> {:ok, contents} end)
   end
 end

--- a/test/deps_test.exs
+++ b/test/deps_test.exs
@@ -1,0 +1,50 @@
+defmodule DepsTest do
+  use ExUnit.Case, async: true
+  alias Mix.Tasks.WandCore.Deps
+  alias WandCore.WandFile
+  alias WandCore.WandFile.Dependency
+
+  import Mox
+
+  setup :verify_on_exit!
+
+  test "returns an empty array if the dependencies are empty" do
+    stub_read(%WandFile{})
+    assert Deps.run([]) == []
+  end
+
+  test "Converts a simple dependency" do
+    %WandFile{
+      dependencies: [
+        %Dependency{name: "poison", requirement: "~>3.1.2"}
+      ]
+    }
+    |> stub_read()
+    assert Deps.run([]) == [
+      {:poison, "~>3.1.2"},
+    ]
+  end
+
+  test "converts a dependency with opts" do
+    %WandFile{
+      dependencies: [
+        %Dependency{
+          name: "poison",
+          requirement: "~>3.1.2",
+          opts: %{
+            only: :test
+          }
+        }
+      ]
+    }
+    |> stub_read()
+    assert Deps.run([]) == [
+      {:poison, "~>3.1.2", only: :test},
+    ]
+  end
+
+  defp stub_read(file) do
+    contents = WandCore.Poison.encode!(file)
+      expect(WandCore.FileMock, :read, fn "wand.json" -> {:ok, contents} end)
+  end
+end

--- a/test/deps_test.exs
+++ b/test/deps_test.exs
@@ -25,6 +25,20 @@ defmodule DepsTest do
     ]
   end
 
+  test "Converts multiple dependencies" do
+    %WandFile{
+      dependencies: [
+        %Dependency{name: "poison", requirement: "~> 3.1.2"},
+        %Dependency{name: "mox", requirement: "~> 1.2.3"}
+      ]
+    }
+    |> stub_read()
+    assert Deps.run([]) == [
+      {:mox, "~> 1.2.3"},
+      {:poison, "~> 3.1.2"},
+    ]
+  end
+
   test "converts a dependency with opts" do
     %WandFile{
       dependencies: [
@@ -40,6 +54,32 @@ defmodule DepsTest do
     |> stub_read()
     assert Deps.run([]) == [
       {:poison, "~>3.1.2", only: :test},
+    ]
+  end
+
+  test "converts a dependency with complex opts" do
+    %WandFile{
+      dependencies: [
+        %Dependency{
+          name: "poison",
+          requirement: "~>3.1.2",
+          opts: %{
+            only: [:test, :dev],
+            compile_env: :prod,
+            runtime: false,
+            git: "https://github.com/devinus/poison.git"
+          }
+        }
+      ]
+    }
+    |> stub_read()
+    assert Deps.run([]) == [
+      {:poison, "~>3.1.2", [
+        compile_env: :prod,
+        git: "https://github.com/devinus/poison.git",
+        only: [:test, :dev],
+        runtime: false,
+      ]},
     ]
   end
 

--- a/test/get_deps_test.exs
+++ b/test/get_deps_test.exs
@@ -7,7 +7,12 @@ defmodule GetDepsTest do
 
   test "prints config" do
     stub_project()
-    expected = [["mox","~> 0.3.2",[["only","test"]]],["ex_doc",">= 0.0.0",[["only","dev"]]]]
+
+    expected = [
+      ["mox", "~> 0.3.2", [["only", "test"]]],
+      ["ex_doc", ">= 0.0.0", [["only", "dev"]]]
+    ]
+
     result = capture_io(fn -> Mix.Tasks.WandCore.GetDeps.run([]) end) |> WandCore.Poison.decode!()
     assert result == expected
   end
@@ -19,6 +24,7 @@ defmodule GetDepsTest do
         {:ex_doc, ">= 0.0.0", [only: :dev]}
       ]
     ]
-    expect(WandCore.ProjectMock, :config, fn() -> config end)
+
+    expect(WandCore.ProjectMock, :config, fn -> config end)
   end
 end

--- a/test/opts_test.exs
+++ b/test/opts_test.exs
@@ -1,0 +1,20 @@
+defmodule OptsTest do
+  use ExUnit.Case, async: true
+  alias WandCore.Opts
+
+  test "encodes an atom" do
+    assert Opts.encode(%{a: :b}) == %{a: ":b"}
+  end
+
+  test "decodes an atom" do
+    assert Opts.decode(%{a: ":b"}) == %{a: :b}
+  end
+
+  test "encodes a string" do
+    assert Opts.encode(%{a: "not:atom"}) == %{a: "not:atom"}
+  end
+
+  test "decodes a string" do
+    assert Opts.decode(%{a: "not:atom"}) == %{a: "not:atom"}
+  end
+end

--- a/test/poison_test.exs
+++ b/test/poison_test.exs
@@ -3,9 +3,11 @@ defmodule WandCore.PoisonTest do
 
   test "encode/decode round trip" do
     data = %{"hello" => "world"}
-    assert data == data
-    |> WandCore.Poison.encode!()
-    |> WandCore.Poison.decode!()
+
+    assert data ==
+             data
+             |> WandCore.Poison.encode!()
+             |> WandCore.Poison.decode!()
   end
 
   test "encodes tuples" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,2 @@
-ExUnit.configure formatters: [JUnitFormatter, ExUnit.CLIFormatter]
+ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
 ExUnit.start()

--- a/test/wand_encoder_test.exs
+++ b/test/wand_encoder_test.exs
@@ -1,0 +1,48 @@
+defmodule WandEncoderTest do
+  use ExUnit.Case, async: true
+  alias WandCore.WandFile
+  alias WandCore.WandFile.Dependency
+  alias WandCore.Poison
+
+  test "Encode an empty WandFile" do
+    assert encode(%WandFile{}) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {}\n}"
+  end
+
+  test "Encode a simple dependency" do
+    file = %WandFile{
+      dependencies: [
+        %Dependency{name: "poison", requirement: ">= 0.0.0"}
+      ]
+    }
+    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": \">= 0.0.0\"\n  }\n}"
+  end
+
+  test "Encode a dependency with an atom as a opt value" do
+    file = %WandFile{
+      dependencies: [
+        %Dependency{name: "poison", requirement: ">= 0.0.0", opts: %{only: :test}}
+      ]
+    }
+    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\n      \">= 0.0.0\",\n      {\n        \"only\": \":test\"\n      }\n    ]\n  }\n}"
+  end
+
+  test "Encode a dependency with a boolean as an opt value" do
+    file = %WandFile{
+      dependencies: [
+        %Dependency{name: "poison", requirement: ">= 0.0.0", opts: %{optional: true}}
+      ]
+    }
+    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\n      \">= 0.0.0\",\n      {\n        \"optional\": \":true\"\n      }\n    ]\n  }\n}"
+  end
+
+  test "Encode a dependency with a list of atoms as a opt value" do
+    file = %WandFile{
+      dependencies: [
+        %Dependency{name: "poison", requirement: ">= 0.0.0", opts: %{only: [:test, :dev]}}
+      ]
+    }
+    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\n      \">= 0.0.0\",\n      {\n        \"only\": [\n          \":test\",\n          \":dev\"\n        ]\n      }\n    ]\n  }\n}"
+  end
+
+  defp encode(file), do: Poison.encode!(file, pretty: true)
+end

--- a/test/wand_encoder_test.exs
+++ b/test/wand_encoder_test.exs
@@ -23,7 +23,7 @@ defmodule WandEncoderTest do
         %Dependency{name: "poison", requirement: ">= 0.0.0", opts: %{only: :test}}
       ]
     }
-    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\n      \">= 0.0.0\",\n      {\n        \"only\": \":test\"\n      }\n    ]\n  }\n}"
+    assert encode(file) ==  "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\">= 0.0.0\",{\"only\":\":test\"}]\n  }\n}"
   end
 
   test "Encode a dependency with a boolean as an opt value" do
@@ -32,7 +32,7 @@ defmodule WandEncoderTest do
         %Dependency{name: "poison", requirement: ">= 0.0.0", opts: %{optional: true}}
       ]
     }
-    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\n      \">= 0.0.0\",\n      {\n        \"optional\": \":true\"\n      }\n    ]\n  }\n}"
+    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\">= 0.0.0\",{\"optional\":\":true\"}]\n  }\n}"
   end
 
   test "Encode a dependency with a list of atoms as a opt value" do
@@ -41,7 +41,7 @@ defmodule WandEncoderTest do
         %Dependency{name: "poison", requirement: ">= 0.0.0", opts: %{only: [:test, :dev]}}
       ]
     }
-    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\n      \">= 0.0.0\",\n      {\n        \"only\": [\n          \":test\",\n          \":dev\"\n        ]\n      }\n    ]\n  }\n}"
+    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\">= 0.0.0\",{\"only\":[\":test\",\":dev\"]}]\n  }\n}"
   end
 
   defp encode(file), do: Poison.encode!(file, pretty: true)

--- a/test/wand_encoder_test.exs
+++ b/test/wand_encoder_test.exs
@@ -14,7 +14,9 @@ defmodule WandEncoderTest do
         %Dependency{name: "poison", requirement: ">= 0.0.0"}
       ]
     }
-    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": \">= 0.0.0\"\n  }\n}"
+
+    assert encode(file) ==
+             "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": \">= 0.0.0\"\n  }\n}"
   end
 
   test "Encode a dependency with an atom as a opt value" do
@@ -23,7 +25,9 @@ defmodule WandEncoderTest do
         %Dependency{name: "poison", requirement: ">= 0.0.0", opts: %{only: :test}}
       ]
     }
-    assert encode(file) ==  "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\">= 0.0.0\",{\"only\":\":test\"}]\n  }\n}"
+
+    assert encode(file) ==
+             "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\">= 0.0.0\",{\"only\":\":test\"}]\n  }\n}"
   end
 
   test "Encode a dependency with a boolean as an opt value" do
@@ -32,7 +36,9 @@ defmodule WandEncoderTest do
         %Dependency{name: "poison", requirement: ">= 0.0.0", opts: %{optional: true}}
       ]
     }
-    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\">= 0.0.0\",{\"optional\":\":true\"}]\n  }\n}"
+
+    assert encode(file) ==
+             "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\">= 0.0.0\",{\"optional\":\":true\"}]\n  }\n}"
   end
 
   test "Encode a dependency with a list of atoms as a opt value" do
@@ -41,7 +47,9 @@ defmodule WandEncoderTest do
         %Dependency{name: "poison", requirement: ">= 0.0.0", opts: %{only: [:test, :dev]}}
       ]
     }
-    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\">= 0.0.0\",{\"only\":[\":test\",\":dev\"]}]\n  }\n}"
+
+    assert encode(file) ==
+             "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\">= 0.0.0\",{\"only\":[\":test\",\":dev\"]}]\n  }\n}"
   end
 
   defp encode(file), do: Poison.encode!(file, pretty: true)

--- a/test/wand_file_test.exs
+++ b/test/wand_file_test.exs
@@ -161,7 +161,7 @@ defmodule WandFileTest do
       file = %WandFile{dependencies: [mox()]}
 
       expected =
-        "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"mox\": [\n      \"~> 0.3.2\",\n      {\n        \"only\": \":test\"\n      }\n    ]\n  }\n}"
+        "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"mox\": [\"~> 0.3.2\",{\"only\":\":test\"}]\n  }\n}"
 
       stub_write(:ok, "wand.json", expected)
       WandFile.save(file)

--- a/test/wand_file_test.exs
+++ b/test/wand_file_test.exs
@@ -161,7 +161,7 @@ defmodule WandFileTest do
       file = %WandFile{dependencies: [mox()]}
 
       expected =
-        "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"mox\": [\n      \"~> 0.3.2\",\n      {\n        \"only\": \"test\"\n      }\n    ]\n  }\n}"
+        "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"mox\": [\n      \"~> 0.3.2\",\n      {\n        \"only\": \":test\"\n      }\n    ]\n  }\n}"
 
       stub_write(:ok, "wand.json", expected)
       WandFile.save(file)
@@ -169,7 +169,7 @@ defmodule WandFileTest do
   end
 
   defp stub_read_valid(path \\ "wand.json") do
-    contents = valid_deps() |> WandCore.Poison.encode!(pretty: true)
+    contents = valid_deps_config() |> WandCore.Poison.encode!(pretty: true)
     stub_read(:ok, path, contents)
   end
 
@@ -191,16 +191,6 @@ defmodule WandFileTest do
     expect(WandCore.FileMock, :write, fn ^path, ^contents -> {:error, :enoent} end)
   end
 
-  defp valid_deps() do
-    %{
-      version: "1.0.1",
-      dependencies: %{
-        mox: ["~> 0.3.2", %{only: "test"}],
-        poison: "~> 3.1"
-      }
-    }
-  end
-
   defp valid_deps_config() do
     %WandFile{
       version: "1.0.1",
@@ -219,7 +209,7 @@ defmodule WandFileTest do
     %WandFile.Dependency{
       name: "mox",
       requirement: "~> 0.3.2",
-      opts: %{only: "test"}
+      opts: %{only: :test}
     }
   end
 end


### PR DESCRIPTION
Adds the task to take wand.json and use it as mix.exs.

In order to support this, the encoder for options now saves atoms as ":name" so they can be decoded later