### PR TITLE
Support dependencies without a requirement

### DIFF
--- a/lib/opts.ex
+++ b/lib/opts.ex
@@ -3,29 +3,25 @@ defmodule WandCore.Opts do
   def decode(opts), do: convert_opts(opts, :decode)
 
   defp convert_opts(%{} = opts, mode) do
+    Enum.map(opts, &convert_tuple(&1, mode))
+    |> Enum.into(%{})
+  end
+
+  defp convert_opts(opts, mode) when is_list(opts) do
     Enum.map(opts, fn
+      {key, value} when is_atom(key) -> convert_tuple({key, value}, mode)
+      value -> convert_tuple({:dummy, value}, mode) |> elem(1)
+    end)
+  end
+
+  defp convert_tuple({key, value}, mode) do
+    case {key, value} do
       {key, value} when is_atom(value) and mode == :encode -> {key, encode_atom(value)}
       {key, ":" <> value} when mode == :decode -> {key, decode_atom(value)}
       {key, value} when is_list(value) -> {key, convert_opts(value, mode)}
       {key, value} when is_map(value) -> {key, convert_opts(value, mode)}
       {key, value} -> {key, value}
-    end)
-    |> Enum.into(%{})
-  end
-
-  defp convert_opts([{key, value} | tail], :encode) when is_atom(value) do
-    [{key, encode_atom(value)} | convert_opts(tail, :encode)]
-  end
-
-  defp convert_opts([{key, ":" <> value} | tail], :decode) do
-    [{key, decode_atom(value)} | convert_opts(tail, :decode)]
-  end
-
-  defp convert_opts(opts, mode) when is_list(opts) do
-    Enum.with_index(opts)
-    |> Enum.into(%{}, fn {k, v} -> {v, k} end)
-    |> convert_opts(mode)
-    |> Map.values()
+    end
   end
 
   defp encode_atom(value), do: ":#{value}"

--- a/lib/tasks/get_deps.ex
+++ b/lib/tasks/get_deps.ex
@@ -16,6 +16,9 @@ defmodule Mix.Tasks.WandCore.GetDeps do
       {name, requirement, opts} ->
         {name, requirement, Opts.encode(opts)}
 
+      {name, opts} when is_list(opts) ->
+        {name, Opts.encode(opts)}
+
       dependency ->
         dependency
     end)

--- a/lib/wand_encoder.ex
+++ b/lib/wand_encoder.ex
@@ -44,6 +44,12 @@ defmodule Wand.WandEncoder do
       Encoder.BitString.encode(requirement, options)
     end
 
+    def encode(%Dependency{requirement: nil, opts: opts}, options) do
+      options = Keyword.drop(options, [:pretty])
+      [WandCore.Opts.encode(opts)]
+      |> Encoder.List.encode(options)
+    end
+
     def encode(%Dependency{requirement: requirement, opts: opts}, options) do
       options = Keyword.drop(options, [:pretty])
 

--- a/lib/wand_encoder.ex
+++ b/lib/wand_encoder.ex
@@ -46,6 +46,7 @@ defmodule Wand.WandEncoder do
 
     def encode(%Dependency{requirement: nil, opts: opts}, options) do
       options = Keyword.drop(options, [:pretty])
+
       [WandCore.Opts.encode(opts)]
       |> Encoder.List.encode(options)
     end

--- a/lib/wand_file.ex
+++ b/lib/wand_file.ex
@@ -59,6 +59,7 @@ defmodule WandCore.WandFile do
   defp validate_dependencies(dependencies) do
     {dependencies, errors} =
       Enum.map(dependencies, fn
+        {name, opts} when is_list(opts) -> create_dependency(name, nil, opts)
         {name, [requirement, opts]} -> create_dependency(name, requirement, opts)
         {name, requirement} -> create_dependency(name, requirement, %{})
       end)
@@ -92,6 +93,10 @@ defmodule WandCore.WandFile do
 
   defp extract_version(%{version: _}), do: {:error, :invalid_version}
   defp extract_version(_data), do: {:error, :missing_version}
+
+  defp create_dependency(name, nil, opts) do
+    %Dependency{name: name, opts: opts}
+  end
 
   defp create_dependency(name, requirement, opts) do
     name = to_string(name)

--- a/lib/wand_file.ex
+++ b/lib/wand_file.ex
@@ -59,8 +59,9 @@ defmodule WandCore.WandFile do
   defp validate_dependencies(dependencies) do
     {dependencies, errors} =
       Enum.map(dependencies, fn
+        {name, [requirement, opts]} when is_map(opts) ->
+          create_dependency(name, requirement, opts)
         {name, opts} when is_list(opts) -> create_dependency(name, nil, opts)
-        {name, [requirement, opts]} -> create_dependency(name, requirement, opts)
         {name, requirement} -> create_dependency(name, requirement, %{})
       end)
       |> Enum.split_with(fn
@@ -95,6 +96,8 @@ defmodule WandCore.WandFile do
   defp extract_version(_data), do: {:error, :missing_version}
 
   defp create_dependency(name, nil, opts) do
+    name = to_string(name)
+    opts = WandCore.Opts.decode(opts)
     %Dependency{name: name, opts: opts}
   end
 

--- a/lib/wand_file.ex
+++ b/lib/wand_file.ex
@@ -61,8 +61,12 @@ defmodule WandCore.WandFile do
       Enum.map(dependencies, fn
         {name, [requirement, opts]} when is_map(opts) ->
           create_dependency(name, requirement, opts)
-        {name, opts} when is_list(opts) -> create_dependency(name, nil, opts)
-        {name, requirement} -> create_dependency(name, requirement, %{})
+
+        {name, opts} when is_list(opts) ->
+          create_dependency(name, nil, opts)
+
+        {name, requirement} ->
+          create_dependency(name, requirement, %{})
       end)
       |> Enum.split_with(fn
         %Dependency{} -> true

--- a/test/get_deps_test.exs
+++ b/test/get_deps_test.exs
@@ -42,7 +42,7 @@ defmodule GetDepsTest do
         "poison",
         [
           ["git", "https://github.com/devinus/poison.git"],
-          ["only", ":dev"],
+          ["only", ":dev"]
         ]
       ]
     ]
@@ -55,7 +55,6 @@ defmodule GetDepsTest do
   end
 
   defp validate(expected) do
-    #Mix.Tasks.WandCore.GetDeps.run([])
     result = capture_io(fn -> Mix.Tasks.WandCore.GetDeps.run([]) end) |> WandCore.Poison.decode!()
     assert result == expected
   end

--- a/test/get_deps_test.exs
+++ b/test/get_deps_test.exs
@@ -31,12 +31,31 @@ defmodule GetDepsTest do
     |> validate()
   end
 
+  test "a git dependency without a requirement" do
+    [
+      {:poison, git: "https://github.com/devinus/poison.git", only: :dev}
+    ]
+    |> stub_project()
+
+    [
+      [
+        "poison",
+        [
+          ["git", "https://github.com/devinus/poison.git"],
+          ["only", ":dev"],
+        ]
+      ]
+    ]
+    |> validate()
+  end
+
   defp stub_project(deps) do
     config = [deps: deps]
     expect(WandCore.ProjectMock, :config, fn -> config end)
   end
 
   defp validate(expected) do
+    #Mix.Tasks.WandCore.GetDeps.run([])
     result = capture_io(fn -> Mix.Tasks.WandCore.GetDeps.run([]) end) |> WandCore.Poison.decode!()
     assert result == expected
   end

--- a/test/opts_test.exs
+++ b/test/opts_test.exs
@@ -22,6 +22,11 @@ defmodule OptsTest do
     assert Opts.encode(a: :b, c: "d") == [a: ":b", c: "d"]
   end
 
+  test "Regression: encodes a keyword list with the last item an atom" do
+
+    assert Opts.encode(a: "b", c: :d) == [a: "b", c: ":d"]
+  end
+
   test "decodes a keyword list" do
     assert Opts.decode(a: ":b", c: "d") == [a: :b, c: "d"]
   end

--- a/test/opts_test.exs
+++ b/test/opts_test.exs
@@ -23,7 +23,6 @@ defmodule OptsTest do
   end
 
   test "Regression: encodes a keyword list with the last item an atom" do
-
     assert Opts.encode(a: "b", c: :d) == [a: "b", c: ":d"]
   end
 

--- a/test/wand_encoder_test.exs
+++ b/test/wand_encoder_test.exs
@@ -52,5 +52,15 @@ defmodule WandEncoderTest do
              "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [\">= 0.0.0\",{\"only\":[\":test\",\":dev\"]}]\n  }\n}"
   end
 
+  test "Encode a dependency without a requirement" do
+    file = %WandFile{
+      dependencies: [
+        %Dependency{name: "poison", opts: %{git: "https://github.com/devinus/poison.git"}}
+      ]
+    }
+
+    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [{\"git\":\"https://github.com/devinus/poison.git\"}]\n  }\n}"
+  end
+
   defp encode(file), do: Poison.encode!(file, pretty: true)
 end

--- a/test/wand_encoder_test.exs
+++ b/test/wand_encoder_test.exs
@@ -59,7 +59,8 @@ defmodule WandEncoderTest do
       ]
     }
 
-    assert encode(file) == "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [{\"git\":\"https://github.com/devinus/poison.git\"}]\n  }\n}"
+    assert encode(file) ==
+             "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"poison\": [{\"git\":\"https://github.com/devinus/poison.git\"}]\n  }\n}"
   end
 
   defp encode(file), do: Poison.encode!(file, pretty: true)

--- a/test/wand_file_test.exs
+++ b/test/wand_file_test.exs
@@ -88,7 +88,7 @@ defmodule WandFileTest do
                 %WandCore.WandFile{
                   dependencies: [
                     %WandCore.WandFile.Dependency{
-                      name: :mox,
+                      name: "mox",
                       opts: [["git"], ["https://github.com/devinus/poison.git"]],
                       requirement: nil
                     }

--- a/test/wand_file_test.exs
+++ b/test/wand_file_test.exs
@@ -68,6 +68,34 @@ defmodule WandFileTest do
       stub_read(:ok, "wand.json", json)
       assert WandFile.load() == {:error, {:invalid_dependency, "mox"}}
     end
+
+    test "a dependency without a requirement" do
+      json =
+        WandCore.Poison.encode!(%{
+          version: "1.0.0",
+          dependencies: %{
+            mox: [
+              ["git"],
+              ["https://github.com/devinus/poison.git"]
+            ]
+          }
+        })
+
+      stub_read(:ok, "wand.json", json)
+
+      assert WandFile.load() ==
+               {:ok,
+                %WandCore.WandFile{
+                  dependencies: [
+                    %WandCore.WandFile.Dependency{
+                      name: :mox,
+                      opts: [["git"], ["https://github.com/devinus/poison.git"]],
+                      requirement: nil
+                    }
+                  ],
+                  version: "1.0.0"
+                }}
+    end
   end
 
   describe "add" do


### PR DESCRIPTION
Wand is currently falling over for git requirements. Support wand files that only have a name and opts